### PR TITLE
Use simple concurrency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ repository = "https://github.com/ridhoq/cya"
 [dependencies]
 anyhow = "1.0"
 clap = "3.0.0-beta.2"
-hyper = { version = "0.14", features = ["full"] }
-hyper-tls = "0.5.0"
+crossbeam-deque = "0.8"
+reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1.2.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,5 @@ repository = "https://github.com/ridhoq/cya"
 [dependencies]
 anyhow = "1.0"
 clap = "3.0.0-beta.2"
-crossbeam-deque = "0.8"
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1.2.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cya"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Ridwan Hoq <ridhoq@users.noreply.github.com>"]
 edition = "2018"
 description = "A HTTP load testing utility"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ anyhow = "1.0"
 clap = "3.0.0-beta.2"
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1.2.0", features = ["full"] }
+uuid = { version = "0.8", features = ["v4"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,17 +1,17 @@
 use clap::Clap;
-use hyper::Uri;
+use reqwest::Url;
 
 #[derive(Clap, Debug)]
 #[clap(version = clap::crate_version!())]
 /// A HTTP load testing utility
 pub struct Opts {
-    /// Number of requests to send to the HTTP URI under test
+    /// Number of requests to send to the HTTP URL under test
     #[clap(short, long, default_value = "1000")]
     pub requests: i32,
     /// Number of workers. Controls concurrency of requests. Not implemented yet
     #[clap(short, long, default_value = "4")]
     pub workers: i32,
-    /// HTTP URI under test
-    #[clap(required = true, name = "URI", parse(try_from_str))]
-    pub uri: Uri,
+    /// HTTP URL under test
+    #[clap(required = true, name = "URL", parse(try_from_str))]
+    pub url: Url,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,9 +8,9 @@ pub struct Opts {
     /// Number of requests to send to the HTTP URL under test
     #[clap(short, long, default_value = "1000")]
     pub requests: i32,
-    /// Number of workers. Controls concurrency of requests. Not implemented yet
-    #[clap(short, long, default_value = "4")]
-    pub workers: i32,
+    /// Maximum number of concurrent connections
+    #[clap(short, long, default_value = "32")]
+    pub connections: i32,
     /// HTTP URL under test
     #[clap(required = true, name = "URL", parse(try_from_str))]
     pub url: Url,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,6 @@ use runner::run_test;
 #[tokio::main]
 async fn main() -> Result<()> {
     let opts: Opts = Opts::parse();
-    run_test(opts.uri, opts.requests, opts.workers).await?;
+    run_test(opts.url, opts.requests, opts.workers).await?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,6 @@ use runner::run_test;
 #[tokio::main]
 async fn main() -> Result<()> {
     let opts: Opts = Opts::parse();
-    run_test(opts.url, opts.requests, opts.workers).await?;
+    run_test(opts.url, opts.requests, opts.connections).await?;
     Ok(())
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -11,9 +11,9 @@ fn get_user_agent(id: Uuid) -> String {
 }
 
 /// Runs the load test
-pub async fn run_test(url_arg: Url, requests: i32, connections: i32) -> Result<()> {
+pub async fn run_test(url: Url, requests: i32, connections: i32) -> Result<()> {
     let correlation_id = Uuid::new_v4();
-    let url = Arc::new(url_arg);
+    let url = Arc::new(url);
     let succeeded = Arc::new(Mutex::new(0));
     let failed = Arc::new(Mutex::new(0));
     

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -28,7 +28,7 @@ pub async fn run_test(url: Url, requests: i32, connections: i32) -> Result<()> {
                 let client = Client::builder().user_agent(get_user_agent(correlation_id)).build()?;
                 client.request(Method::GET, url.as_str()).send().await
             });
-            sender.send(handle).await;
+            sender.send(handle).await.expect("Failed to send to receiver");
         }
     });
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,33 +1,23 @@
 use anyhow::Result;
-use hyper::client::HttpConnector;
-use hyper::{Body, Client, Request, Uri};
-use hyper_tls::HttpsConnector;
+use reqwest::{Client, Request, Method, Url, Response};
 
-type CyaHttpsConnector = HttpsConnector<HttpConnector>;
-type CyaClient = Client<CyaHttpsConnector, Body>;
+fn get_user_agent() -> String {
+    format!("{} {}", clap::crate_name!(), clap::crate_version!())
+}
 
 /// Runs the load test
-pub async fn run_test(uri: Uri, requests: i32, _workers: i32) -> Result<()> {
-    let https = HttpsConnector::new();
-    let client = Client::builder().build::<CyaHttpsConnector, Body>(https);
+pub async fn run_test(url: Url, requests: i32, _workers: i32) -> Result<()> {
+    let client = Client::builder()
+        .user_agent(get_user_agent())
+        .build()?;
     for _ in 0..requests {
-        request(&client, &uri).await?;
+        request(&client, &url).await?;
     }
     Ok(())
 }
 
-pub async fn request(client: &CyaClient, uri: &Uri) -> Result<()> {
-    let req = Request::builder()
-        .method("GET")
-        .uri(uri)
-        .header(
-            "User-Agent",
-            format!("{} {}", clap::crate_name!(), clap::crate_version!()),
-        )
-        // TODO: couldn't figure out how to not pass a body with the Request::builder
-        // TODO: pass in a real body when doing POST/PUT/etc
-        .body(Body::from(""))
-        .unwrap();
-    client.request(req).await?;
+pub async fn request(client: &Client, url: &Url) -> Result<()> {
+    let req = client.request(Method::GET, &url.to_string());
+    req.send().await?;
     Ok(())
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,23 +1,50 @@
 use anyhow::Result;
-use reqwest::{Client, Request, Method, Url, Response};
+// use async_std::channel::unbounded;
+// use async_std::task;
+use reqwest::{Client, Method, Request, Response, Url};
+use std::option::Option::Some;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio::task;
+use std::ops::Add;
 
 fn get_user_agent() -> String {
-    format!("{} {}", clap::crate_name!(), clap::crate_version!())
+    format!("{}/{}", clap::crate_name!(), clap::crate_version!())
 }
 
 /// Runs the load test
-pub async fn run_test(url: Url, requests: i32, _workers: i32) -> Result<()> {
-    let client = Client::builder()
-        .user_agent(get_user_agent())
-        .build()?;
-    for _ in 0..requests {
-        request(&client, &url).await?;
-    }
-    Ok(())
-}
+pub async fn run_test(url_arg: Url, requests: i32, _workers: i32) -> Result<()> {
+    let url = Arc::new(url_arg);
+    let mut succeeded = 0;
 
-pub async fn request(client: &Client, url: &Url) -> Result<()> {
-    let req = client.request(Method::GET, &url.to_string());
-    req.send().await?;
+    let (sender, mut reciever) = mpsc::channel(32);
+    let send_handle = task::spawn(async move {
+        let url_clone = url.clone();
+        for _ in 0..requests {
+            let url_clone_clone = url_clone.clone();
+            let handle = task::spawn(async move {
+                let url_clone_clone_clone = url_clone_clone.clone();
+                let client = Client::builder().user_agent(get_user_agent()).build()?;
+                client
+                    .request(Method::GET, url_clone_clone_clone.as_str())
+                    .send()
+                    .await
+            });
+            sender.send(handle).await;
+        }
+    });
+
+    let recieve_handle = task::spawn(async move {
+        while let Some(res) = reciever.recv().await {
+            let thing = res.await.expect("oops");
+            let real_res = thing.expect("oof");
+            if real_res.status().is_success() {
+                succeeded += 1;
+            }
+        }
+    });
+
+    recieve_handle.await?;
+    println!("succeeded requests: {}", succeeded);
     Ok(())
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -11,14 +11,14 @@ fn get_user_agent(id: Uuid) -> String {
 }
 
 /// Runs the load test
-/// 
+///
 /// The load tester generates load by spawning tasks that make the HTTP request.
 /// It creates a channel that is bounded by the connections argument which effectively controls the
 /// number of concurrent connections at any given time.
-/// 
+///
 /// The sender task starts a task that makes the HTTP request and sends the handle of that task to
 /// the receiver task
-/// 
+///
 /// The receiver task awaits the result of the HTTP request tasks and counts the number of successes
 /// and failures. In the future, this will do further aggregation of response status codes and durations.
 pub async fn run_test(url: Url, requests: i32, connections: i32) -> Result<()> {
@@ -33,9 +33,9 @@ pub async fn run_test(url: Url, requests: i32, connections: i32) -> Result<()> {
     let failed = Arc::new(Mutex::new(0));
 
     println!("correlation id: {}", correlation_id);
-    
+
     let (sender, mut reciever) = mpsc::channel(connections as usize);
-    
+
     task::spawn(async move {
         for _ in 0..requests {
             let client = Arc::clone(&client);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -16,16 +16,12 @@ pub async fn run_test(url_arg: Url, requests: i32, _workers: i32) -> Result<()> 
 
     let (sender, mut reciever) = mpsc::channel(32);
     task::spawn(async move {
-        let url_clone = url.clone();
         for _ in 0..requests {
-            let url_clone_clone = url_clone.clone();
+            let url = Arc::clone(&url);
             let handle = task::spawn(async move {
-                let url_clone_clone_clone = url_clone_clone.clone();
+                let url = Arc::clone(&url);
                 let client = Client::builder().user_agent(get_user_agent()).build()?;
-                client
-                    .request(Method::GET, url_clone_clone_clone.as_str())
-                    .send()
-                    .await
+                client.request(Method::GET, url.as_str()).send().await
             });
             sender.send(handle).await;
         }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -10,11 +10,11 @@ fn get_user_agent() -> String {
 }
 
 /// Runs the load test
-pub async fn run_test(url_arg: Url, requests: i32, _workers: i32) -> Result<()> {
+pub async fn run_test(url_arg: Url, requests: i32, connections: i32) -> Result<()> {
     let url = Arc::new(url_arg);
     let succeeded = Arc::new(Mutex::new(0));
 
-    let (sender, mut reciever) = mpsc::channel(32);
+    let (sender, mut reciever) = mpsc::channel(connections as usize);
     task::spawn(async move {
         for _ in 0..requests {
             let url = Arc::clone(&url);


### PR DESCRIPTION
Concurrency is achieved by using a channel to spawn tasks for each request and send the result of the request on the channel.

Closes #2 