### PR TITLE
Stats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ repository = "https://github.com/ridhoq/cya"
 
 [dependencies]
 anyhow = "1.0"
+average = "0.10.6"
 clap = "3.0.0-beta.2"
+#hdrhistogram = "7.2.0"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,7 @@ repository = "https://github.com/ridhoq/cya"
 anyhow = "1.0"
 clap = "3.0.0-beta.2"
 reqwest = { version = "0.11", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 tokio = { version = "1.2.0", features = ["full"] }
 uuid = { version = "0.8", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/ridhoq/cya"
 anyhow = "1.0"
 average = "0.10.6"
 clap = "3.0.0-beta.2"
-#hdrhistogram = "7.2.0"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,20 +1,32 @@
 use anyhow::Result;
-use reqwest::{Client, Method, Url};
+use average::{Estimate, Max, Min, Quantile};
+use reqwest::{Client, Method, Url, Response, Error};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::option::Option::Some;
 use std::sync::Arc;
+use std::time::{Instant, Duration};
 use tokio::sync::mpsc;
 use tokio::task;
 use uuid::Uuid;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+struct CyaHistogram {
+    min: f64,
+    p50: f64,
+    p95: f64,
+    p99: f64,
+    max: f64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct CyaResult {
     succeeded: i32,
     failed: i32,
+    histogram: CyaHistogram,
     response_codes: HashMap<String, i32>,
-    correlation_id: String,
 }
 
 fn get_user_agent(id: Uuid) -> String {
@@ -45,6 +57,8 @@ pub async fn run_test(url: Url, requests: i32, connections: i32) -> Result<()> {
 
     let (sender, mut reciever) = mpsc::channel(connections as usize);
 
+    let now = Instant::now();
+
     task::spawn(async move {
         for _ in 0..requests {
             let client = Arc::clone(&client);
@@ -62,37 +76,69 @@ pub async fn run_test(url: Url, requests: i32, connections: i32) -> Result<()> {
     });
 
     let receive_handle = task::spawn(async move {
-        let mut succeeded = 0;
-        let mut failed = 0;
-        let mut response_codes = HashMap::new();
+        let mut response_results = vec![];
 
         while let Some(handle) = reciever.recv().await {
             let result = handle.await.expect("oops");
-            match result {
-                Ok(res) => {
-                    let response_code_count =
-                        response_codes.entry(res.status().to_string()).or_insert(0);
-                    *response_code_count += 1;
-                    if res.status().is_success() {
-                        succeeded += 1;
-                    }
-                }
-                Err(err) => {
-                    failed += 1;
-                }
-            }
+            let duration = now.elapsed();
+            response_results.push((result, duration));
         }
 
-        let result = CyaResult {
-            succeeded,
-            failed,
-            response_codes,
-            correlation_id: correlation_id.to_string(),
-        };
+        let result = get_cya_result(response_results);
         let serialized = serde_json::to_string_pretty(&result).unwrap();
         println!("{}", serialized);
     });
 
     receive_handle.await?;
     Ok(())
+}
+
+fn get_cya_result(response_results: Vec<(Result<Response, Error>, Duration)>) -> CyaResult {
+    let mut succeeded = 0;
+    let mut failed = 0;
+    let mut response_codes = HashMap::new();
+    
+    let mut min = Min::new();
+    let mut p50 = Quantile::new(0.5);
+    let mut p95 = Quantile::new(0.95);
+    let mut p99 = Quantile::new(0.99);
+    let mut max = Max::new();
+    
+    for (result, duration) in response_results {
+        let duration = duration.as_secs_f64();
+        min.add(duration);
+        p50.add(duration);
+        p95.add(duration);
+        p99.add(duration);
+        max.add(duration);
+        
+        match result {
+            Ok(res) => {
+                let response_code_count =
+                    response_codes.entry(res.status().to_string()).or_insert(0);
+                *response_code_count += 1;
+                if res.status().is_success() {
+                    succeeded += 1;
+                }
+            }
+            Err(_) => {
+                failed += 1;
+            }
+        }
+    }
+    
+    let histogram = CyaHistogram {
+        min: min.min(),
+        p50: p50.quantile(),
+        p95: p95.quantile(),
+        p99: p99.quantile(),
+        max: max.max(),
+    };
+    
+    CyaResult {
+        succeeded,
+        failed,
+        histogram,
+        response_codes,
+    }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,10 +1,21 @@
 use anyhow::Result;
 use reqwest::{Client, Method, Url};
+use serde::Serialize;
+use std::collections::HashMap;
 use std::option::Option::Some;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::task;
 use uuid::Uuid;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CyaResult {
+    succeeded: i32,
+    failed: i32,
+    response_codes: HashMap<String, i32>,
+    correlation_id: String,
+}
 
 fn get_user_agent(id: Uuid) -> String {
     format!("{}/{}/{}", clap::crate_name!(), clap::crate_version!(), id)
@@ -29,8 +40,6 @@ pub async fn run_test(url: Url, requests: i32, connections: i32) -> Result<()> {
             .build()?,
     );
     let url = Arc::new(url);
-    let succeeded = Arc::new(Mutex::new(0));
-    let failed = Arc::new(Mutex::new(0));
 
     println!("correlation id: {}", correlation_id);
 
@@ -53,26 +62,35 @@ pub async fn run_test(url: Url, requests: i32, connections: i32) -> Result<()> {
     });
 
     let receive_handle = task::spawn(async move {
+        let mut succeeded = 0;
+        let mut failed = 0;
+        let mut response_codes = HashMap::new();
+
         while let Some(handle) = reciever.recv().await {
             let result = handle.await.expect("oops");
             match result {
                 Ok(res) => {
+                    let response_code_count =
+                        response_codes.entry(res.status().to_string()).or_insert(0);
+                    *response_code_count += 1;
                     if res.status().is_success() {
-                        let mut succeeded = succeeded.lock().expect("Could not acquire lock");
-                        *succeeded += 1;
+                        succeeded += 1;
                     }
                 }
-                Err(_) => {
-                    let mut failed = failed.lock().expect("Could not acquire lock");
-                    *failed += 1;
+                Err(err) => {
+                    failed += 1;
                 }
             }
         }
 
-        let succeeded = succeeded.lock().unwrap();
-        let failed = failed.lock().unwrap();
-        println!("succeeded requests: {}", *succeeded);
-        println!("failed requests: {}", *failed);
+        let result = CyaResult {
+            succeeded,
+            failed,
+            response_codes,
+            correlation_id: correlation_id.to_string(),
+        };
+        let serialized = serde_json::to_string_pretty(&result).unwrap();
+        println!("{}", serialized);
     });
 
     receive_handle.await?;


### PR DESCRIPTION
Print some stats about the results of the load test.

Adds the histogram, response codes, and failure reasons. Here's what the output looks like now:
```
{
  "succeeded": 1000,
  "failed": 0,
  "histogram": {
    "min": 1.06257007,
    "p50": 2.7549791175743503,
    "p95": 3.0050678069675727,
    "p99": 3.005917790876449,
    "max": 3.0059687
  },
  "responseCodes": {
    "200 OK": 1000
  },
  "failureReasons": {
    "body": 0,
    "builder": 0,
    "connect": 0,
    "decode": 0,
    "redirect": 0,
    "status": 0,
    "timeout": 0
  }
}
```